### PR TITLE
explicitly declare as TAP_PACKAGE

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,0 +1,1 @@
+TAP_PACKAGE=1


### PR DESCRIPTION
This is needed so that lsstsw acknowledges that this is a TAP package (it was getting confused by the presence of a README in the root directory).
