### PR TITLE
force setuptools to use $CC for linking

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,1 +1,5 @@
+# shellcheck shell=bash
+
+# shellcheck disable=SC2034
 TAP_PACKAGE=1
+export LDSHARED="${CC} -shared"


### PR DESCRIPTION
setuptools.Extension() seems to default to using $CC for the build but
uses the same compiler string as python was built with for linking.